### PR TITLE
Refactor: Remove redundant Handlebars helper registration

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,12 +1,5 @@
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
-import Handlebars from 'handlebars';
-
-// Register the 'eq' helper
-Handlebars.registerHelper('eq', function(arg1, arg2) {
-  return arg1 === arg2;
-});
-
 export const ai = genkit({
   plugins: [googleAI()],
   model: 'googleai/gemini-2.0-flash',


### PR DESCRIPTION
The 'eq' helper was registered both globally and within the Genkit configuration. This commit removes the global registration to centralize helper definitions within the Genkit initialization, which is the intended mechanism for Genkit-managed Handlebars instances.

This is a preliminary step in addressing an issue where the 'eq' helper was reported as unknown in an electrical advice prompt, suggesting a potential problem with helper propagation or `knownHelpersOnly` enforcement at the prompt level.